### PR TITLE
Use the proper token name to list duplicate modules

### DIFF
--- a/Policy/drupal-8/moduleDuplicates.policy.yml
+++ b/Policy/drupal-8/moduleDuplicates.policy.yml
@@ -12,7 +12,7 @@ remediation: |
   codebase.
 success: No duplicate modules found.
 failure: |
-  Duplicate modules found
-  {{# modules}}
-  * {{name}}
-  {{/ modules}}
+  Duplicate modules found:
+  {{# duplicate_modules}}
+  * {{.}}
+  {{/ duplicate_modules}}


### PR DESCRIPTION
The output of this policy will now list the duplicate modules.

```
## Policy Outcome
### No duplicate modules found

❌  Failed [severity=medium]

Duplicate modules can cause a variety of strange behaviors should Drupal ever
unexpectedly load the wrong version.

Duplicate modules found
* field
```